### PR TITLE
[ENH] Add Axios timeout and AbortController per-request cleanup (addressing issue #12)

### DIFF
--- a/aegis/frontend/src/pages/IncidentDetail.tsx
+++ b/aegis/frontend/src/pages/IncidentDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useIncidentStore } from "../stores/incidentStore";
 import { approveIncident, dismissIncident, getIncidentReport } from "../api/endpoints";
@@ -8,6 +8,13 @@ import SqlBlock from "../components/SqlBlock";
 import BlastRadiusGraph from "../components/BlastRadiusGraph";
 
 export default function IncidentDetail() {
+  const controllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    controllerRef.current = new AbortController();
+    return () => controllerRef.current!.abort();
+  }, []);
+
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { current: incident, fetchIncident, loading } = useIncidentStore();
@@ -17,8 +24,10 @@ export default function IncidentDetail() {
 
   useEffect(() => {
     if (id) {
-      fetchIncident(Number(id));
-      getIncidentReport(Number(id)).then(setReport).catch(() => setReport(null));
+      fetchIncident(Number(id), controllerRef.current?.signal);
+      getIncidentReport(Number(id), controllerRef.current?.signal)
+        .then(setReport)
+        .catch(() => setReport(null));
     }
   }, [id, fetchIncident]);
 

--- a/aegis/frontend/src/pages/LineageExplorer.tsx
+++ b/aegis/frontend/src/pages/LineageExplorer.tsx
@@ -1,10 +1,17 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useLineageStore } from "../stores/lineageStore";
 import { getConnections } from "../api/endpoints";
 import type { Connection } from "../api/types";
 import LineageGraphComponent from "../components/LineageGraph";
 
 export default function LineageExplorer() {
+  const controllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    controllerRef.current = new AbortController();
+    return () => controllerRef.current!.abort();
+  }, []);
+
   const { graph, loading, fetchGraph } = useLineageStore();
   const [search, setSearch] = useState("");
   const [selectedNode, setSelectedNode] = useState<string | null>(null);
@@ -12,11 +19,11 @@ export default function LineageExplorer() {
   const [selectedConnectionId, setSelectedConnectionId] = useState<number | undefined>(undefined);
 
   useEffect(() => {
-    getConnections().then(setConnections).catch(() => {});
+    getConnections(controllerRef.current?.signal).then(setConnections).catch(() => {});
   }, []);
 
   useEffect(() => {
-    fetchGraph(selectedConnectionId);
+    fetchGraph(selectedConnectionId, controllerRef.current?.signal);
   }, [selectedConnectionId, fetchGraph]);
 
   const filteredHighlight = search.trim()

--- a/aegis/frontend/src/pages/Overview.tsx
+++ b/aegis/frontend/src/pages/Overview.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { clsx } from "clsx";
 import { useSystemStore } from "../stores/systemStore";
@@ -18,10 +18,17 @@ export default function Overview() {
   const { incidents, fetchIncidents } = useIncidentStore();
   const { tables, fetchTables } = useTableStore();
 
+  const controllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    controllerRef.current = new AbortController();
+    return () => controllerRef.current!.abort();
+  }, []);
+
   useAutoRefresh(() => {
-    fetchStats();
-    fetchIncidents();
-    fetchTables();
+    fetchStats(controllerRef.current?.signal);
+    fetchIncidents(undefined, controllerRef.current?.signal);
+    fetchTables(undefined, controllerRef.current?.signal);
   }, 30_000);
 
   const handleWsMessage = useCallback(
@@ -30,11 +37,11 @@ export default function Overview() {
         event.event === "incident.created" ||
         event.event === "incident.updated"
       ) {
-        fetchIncidents();
-        fetchStats();
+        fetchIncidents(undefined, controllerRef.current?.signal);
+        fetchStats(controllerRef.current?.signal);
       }
       if (event.event === "scan.completed") {
-        fetchStats();
+        fetchStats(controllerRef.current?.signal);
       }
     },
     [fetchIncidents, fetchStats]

--- a/aegis/frontend/src/pages/Settings.tsx
+++ b/aegis/frontend/src/pages/Settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getConnections, deleteConnection, triggerScan } from "../api/endpoints";
 import { useTableStore } from "../stores/tableStore";
 import ConnectionForm from "../components/ConnectionForm";
@@ -41,14 +41,17 @@ export default function Settings() {
 function ConnectionsTab() {
   const [connections, setConnections] = useState<Connection[]>([]);
   const [showForm, setShowForm] = useState(false);
+  const controllerRef = useRef<AbortController | null>(null);
 
   const load = async () => {
-    const data = await getConnections();
+    const data = await getConnections().catch(() => [] as Connection[]);
     setConnections(data);
   };
 
   useEffect(() => {
-    load();
+    controllerRef.current = new AbortController();
+    getConnections(controllerRef.current.signal).then(setConnections).catch(() => {});
+    return () => controllerRef.current!.abort();
   }, []);
 
   const handleDelete = async (id: number) => {
@@ -113,9 +116,12 @@ function ConnectionsTab() {
 
 function TablesTab() {
   const { tables, fetchTables } = useTableStore();
+  const controllerRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
-    fetchTables();
+    controllerRef.current = new AbortController();
+    fetchTables(undefined, controllerRef.current.signal);
+    return () => controllerRef.current!.abort();
   }, [fetchTables]);
 
   return (

--- a/aegis/frontend/src/stores/__tests__/incidentStore.test.ts
+++ b/aegis/frontend/src/stores/__tests__/incidentStore.test.ts
@@ -1,0 +1,49 @@
+import { vi, it, expect, beforeEach, describe } from "vitest";
+import axios from "axios";
+import { useIncidentStore } from "../incidentStore";
+
+vi.mock("../../api/endpoints", () => ({
+  getIncidents: vi.fn(),
+  getIncident: vi.fn(),
+}));
+
+import { getIncidents, getIncident } from "../../api/endpoints";
+
+describe("incidentStore", () => {
+  beforeEach(() => {
+    useIncidentStore.setState({ incidents: [], current: null, loading: false });
+    vi.clearAllMocks();
+  });
+
+  it("forwards signal to getIncidents", async () => {
+    vi.mocked(getIncidents).mockResolvedValue([]);
+    const controller = new AbortController();
+    await useIncidentStore.getState().fetchIncidents(undefined, controller.signal);
+    expect(vi.mocked(getIncidents)).toHaveBeenCalledWith(undefined, controller.signal);
+  });
+
+  it("forwards signal to getIncident", async () => {
+    vi.mocked(getIncident).mockResolvedValue({ id: 1 } as any);
+    const controller = new AbortController();
+    await useIncidentStore.getState().fetchIncident(1, controller.signal);
+    expect(vi.mocked(getIncident)).toHaveBeenCalledWith(1, controller.signal);
+  });
+
+  it("does not update state when getIncidents is aborted", async () => {
+    vi.mocked(getIncidents).mockRejectedValue(new axios.CanceledError());
+    const controller = new AbortController();
+    controller.abort();
+    await useIncidentStore.getState().fetchIncidents(undefined, controller.signal);
+    expect(useIncidentStore.getState().incidents).toEqual([]);
+    expect(useIncidentStore.getState().loading).toBe(false);
+  });
+
+  it("does not update state when getIncident is aborted", async () => {
+    vi.mocked(getIncident).mockRejectedValue(new axios.CanceledError());
+    const controller = new AbortController();
+    controller.abort();
+    await useIncidentStore.getState().fetchIncident(1, controller.signal);
+    expect(useIncidentStore.getState().current).toBeNull();
+    expect(useIncidentStore.getState().loading).toBe(false);
+  });
+});

--- a/aegis/frontend/src/stores/__tests__/incidentStore.test.ts
+++ b/aegis/frontend/src/stores/__tests__/incidentStore.test.ts
@@ -46,4 +46,11 @@ describe("incidentStore", () => {
     expect(useIncidentStore.getState().current).toBeNull();
     expect(useIncidentStore.getState().loading).toBe(false);
   });
+
+  it("rethrows non-cancel errors from fetchIncident", async () => {
+    const networkError = new Error("Network Error");
+    vi.mocked(getIncident).mockRejectedValue(networkError);
+    await expect(useIncidentStore.getState().fetchIncident(1)).rejects.toThrow("Network Error");
+    expect(useIncidentStore.getState().loading).toBe(false);
+  });
 });

--- a/aegis/frontend/src/stores/__tests__/lineageStore.test.ts
+++ b/aegis/frontend/src/stores/__tests__/lineageStore.test.ts
@@ -1,0 +1,38 @@
+import { vi, it, expect, beforeEach, describe } from "vitest";
+import axios from "axios";
+import { useLineageStore } from "../lineageStore";
+
+vi.mock("../../api/endpoints", () => ({
+  getLineageGraph: vi.fn(),
+}));
+
+import { getLineageGraph } from "../../api/endpoints";
+
+describe("lineageStore", () => {
+  beforeEach(() => {
+    useLineageStore.setState({ graph: null, loading: false });
+    vi.clearAllMocks();
+  });
+
+  it("forwards signal to getLineageGraph", async () => {
+    vi.mocked(getLineageGraph).mockResolvedValue({ nodes: [], edges: [] });
+    const controller = new AbortController();
+    await useLineageStore.getState().fetchGraph(undefined, controller.signal);
+    expect(vi.mocked(getLineageGraph)).toHaveBeenCalledWith(undefined, controller.signal);
+  });
+
+  it("does not update state when aborted", async () => {
+    vi.mocked(getLineageGraph).mockRejectedValue(new axios.CanceledError());
+    const controller = new AbortController();
+    controller.abort();
+    await useLineageStore.getState().fetchGraph(undefined, controller.signal);
+    expect(useLineageStore.getState().graph).toBeNull();
+    expect(useLineageStore.getState().loading).toBe(false);
+  });
+
+  it("rethrows non-cancel errors", async () => {
+    vi.mocked(getLineageGraph).mockRejectedValue(new Error("Network error"));
+    await expect(useLineageStore.getState().fetchGraph()).rejects.toThrow("Network error");
+    expect(useLineageStore.getState().loading).toBe(false);
+  });
+});

--- a/aegis/frontend/src/stores/__tests__/systemStore.test.ts
+++ b/aegis/frontend/src/stores/__tests__/systemStore.test.ts
@@ -9,12 +9,12 @@ vi.mock("../../api/endpoints", () => ({
 
 import { getStats, getStatus } from "../../api/endpoints";
 
-beforeEach(() => {
-  useSystemStore.setState({ stats: null, llmEnabled: null, loading: false });
-  vi.clearAllMocks();
-});
-
 describe("systemStore", () => {
+  beforeEach(() => {
+    useSystemStore.setState({ stats: null, llmEnabled: null, loading: false });
+    vi.clearAllMocks();
+  });
+
   it("forwards signal to getStats", async () => {
     vi.mocked(getStats).mockResolvedValue({ health_score: 99, total_tables: 1, healthy_tables: 1, open_incidents: 0, critical_incidents: 0, anomalies_24h: 0, avg_resolution_time_minutes: null });
     const controller = new AbortController();
@@ -29,6 +29,13 @@ describe("systemStore", () => {
     controller.abort();
     await useSystemStore.getState().fetchStats(controller.signal);
     expect(useSystemStore.getState().stats).toBeNull();
+    expect(useSystemStore.getState().loading).toBe(false);
+  });
+
+  it("rethrows non-cancel errors from fetchStats", async () => {
+    const networkError = new Error("Network Error");
+    vi.mocked(getStats).mockRejectedValue(networkError);
+    await expect(useSystemStore.getState().fetchStats()).rejects.toThrow("Network Error");
     expect(useSystemStore.getState().loading).toBe(false);
   });
 

--- a/aegis/frontend/src/stores/__tests__/systemStore.test.ts
+++ b/aegis/frontend/src/stores/__tests__/systemStore.test.ts
@@ -1,0 +1,48 @@
+import { vi, it, expect, beforeEach, describe } from "vitest";
+import axios from "axios";
+import { useSystemStore } from "../systemStore";
+
+vi.mock("../../api/endpoints", () => ({
+  getStats: vi.fn(),
+  getStatus: vi.fn(),
+}));
+
+import { getStats, getStatus } from "../../api/endpoints";
+
+beforeEach(() => {
+  useSystemStore.setState({ stats: null, llmEnabled: null, loading: false });
+  vi.clearAllMocks();
+});
+
+describe("systemStore", () => {
+  it("forwards signal to getStats", async () => {
+    vi.mocked(getStats).mockResolvedValue({ health_score: 99, total_tables: 1, healthy_tables: 1, open_incidents: 0, critical_incidents: 0, anomalies_24h: 0, avg_resolution_time_minutes: null });
+    const controller = new AbortController();
+    await useSystemStore.getState().fetchStats(controller.signal);
+    expect(getStats).toHaveBeenCalledWith(controller.signal);
+  });
+
+  it("does not update state when aborted", async () => {
+    const cancelError = new axios.CanceledError();
+    vi.mocked(getStats).mockRejectedValue(cancelError);
+    const controller = new AbortController();
+    controller.abort();
+    await useSystemStore.getState().fetchStats(controller.signal);
+    expect(useSystemStore.getState().stats).toBeNull();
+    expect(useSystemStore.getState().loading).toBe(false);
+  });
+
+  it("leaves llmEnabled null when getStatus rejects with CanceledError", async () => {
+    vi.mocked(getStatus).mockRejectedValue(new axios.CanceledError());
+    const controller = new AbortController();
+    controller.abort();
+    await useSystemStore.getState().fetchStatus(controller.signal);
+    expect(useSystemStore.getState().llmEnabled).toBeNull();
+  });
+
+  it("leaves llmEnabled null when getStatus rejects with a network error", async () => {
+    vi.mocked(getStatus).mockRejectedValue(new Error("Network Error"));
+    await useSystemStore.getState().fetchStatus();
+    expect(useSystemStore.getState().llmEnabled).toBeNull();
+  });
+});

--- a/aegis/frontend/src/stores/__tests__/tableStore.test.ts
+++ b/aegis/frontend/src/stores/__tests__/tableStore.test.ts
@@ -1,0 +1,38 @@
+import { vi, it, expect, beforeEach, describe } from "vitest";
+import axios from "axios";
+import { useTableStore } from "../tableStore";
+
+vi.mock("../../api/endpoints", () => ({
+  getTables: vi.fn(),
+}));
+
+import { getTables } from "../../api/endpoints";
+
+describe("tableStore", () => {
+  beforeEach(() => {
+    useTableStore.setState({ tables: [], loading: false });
+    vi.clearAllMocks();
+  });
+
+  it("forwards signal to getTables", async () => {
+    vi.mocked(getTables).mockResolvedValue([]);
+    const controller = new AbortController();
+    await useTableStore.getState().fetchTables(undefined, controller.signal);
+    expect(vi.mocked(getTables)).toHaveBeenCalledWith(undefined, controller.signal);
+  });
+
+  it("does not update state when aborted", async () => {
+    vi.mocked(getTables).mockRejectedValue(new axios.CanceledError());
+    const controller = new AbortController();
+    controller.abort();
+    await useTableStore.getState().fetchTables(undefined, controller.signal);
+    expect(useTableStore.getState().tables).toEqual([]);
+    expect(useTableStore.getState().loading).toBe(false);
+  });
+
+  it("does not update state on network error (rethrows)", async () => {
+    vi.mocked(getTables).mockRejectedValue(new Error("Network error"));
+    await expect(useTableStore.getState().fetchTables()).rejects.toThrow("Network error");
+    expect(useTableStore.getState().loading).toBe(false);
+  });
+});

--- a/aegis/frontend/src/stores/incidentStore.ts
+++ b/aegis/frontend/src/stores/incidentStore.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { create } from "zustand";
 import type { Incident } from "../api/types";
 import { getIncidents, getIncident } from "../api/endpoints";
@@ -6,31 +7,35 @@ interface IncidentState {
   incidents: Incident[];
   current: Incident | null;
   loading: boolean;
-  fetchIncidents: (params?: { status?: string; severity?: string }) => Promise<void>;
-  fetchIncident: (id: number) => Promise<void>;
+  fetchIncidents: (params?: { status?: string; severity?: string }, signal?: AbortSignal) => Promise<void>;
+  fetchIncident: (id: number, signal?: AbortSignal) => Promise<void>;
   updateIncident: (incident: Incident) => void;
 }
 
-export const useIncidentStore = create<IncidentState>((set, get) => ({
+export const useIncidentStore = create<IncidentState>((set) => ({
   incidents: [],
   current: null,
   loading: false,
 
-  fetchIncidents: async (params) => {
+  fetchIncidents: async (params, signal) => {
     set({ loading: true });
     try {
-      const data = await getIncidents(params);
+      const data = await getIncidents(params, signal);
       set({ incidents: data });
+    } catch (e) {
+      if (!axios.isCancel(e)) throw e;
     } finally {
       set({ loading: false });
     }
   },
 
-  fetchIncident: async (id) => {
+  fetchIncident: async (id, signal) => {
     set({ loading: true });
     try {
-      const data = await getIncident(id);
+      const data = await getIncident(id, signal);
       set({ current: data });
+    } catch (e) {
+      if (!axios.isCancel(e)) throw e;
     } finally {
       set({ loading: false });
     }

--- a/aegis/frontend/src/stores/lineageStore.ts
+++ b/aegis/frontend/src/stores/lineageStore.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { create } from "zustand";
 import type { LineageGraph } from "../api/types";
 import { getLineageGraph } from "../api/endpoints";
@@ -5,19 +6,21 @@ import { getLineageGraph } from "../api/endpoints";
 interface LineageState {
   graph: LineageGraph | null;
   loading: boolean;
-  fetchGraph: (connectionId?: number) => Promise<void>;
+  fetchGraph: (connectionId?: number, signal?: AbortSignal) => Promise<void>;
 }
 
 export const useLineageStore = create<LineageState>((set) => ({
   graph: null,
   loading: false,
 
-  fetchGraph: async (connectionId) => {
+  fetchGraph: async (connectionId, signal) => {
     set({ loading: true });
     try {
       const params = connectionId ? { connection_id: connectionId } : undefined;
-      const data = await getLineageGraph(params);
+      const data = await getLineageGraph(params, signal);
       set({ graph: data });
+    } catch (e) {
+      if (!axios.isCancel(e)) throw e;
     } finally {
       set({ loading: false });
     }

--- a/aegis/frontend/src/stores/systemStore.ts
+++ b/aegis/frontend/src/stores/systemStore.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { create } from "zustand";
 import type { Stats } from "../api/types";
 import { getStats, getStatus } from "../api/endpoints";
@@ -6,8 +7,8 @@ interface SystemState {
   stats: Stats | null;
   llmEnabled: boolean | null;
   loading: boolean;
-  fetchStats: () => Promise<void>;
-  fetchStatus: () => Promise<void>;
+  fetchStats: (signal?: AbortSignal) => Promise<void>;
+  fetchStatus: (signal?: AbortSignal) => Promise<void>;
 }
 
 export const useSystemStore = create<SystemState>((set) => ({
@@ -15,22 +16,24 @@ export const useSystemStore = create<SystemState>((set) => ({
   llmEnabled: null,
   loading: false,
 
-  fetchStats: async () => {
+  fetchStats: async (signal) => {
     set({ loading: true });
     try {
-      const data = await getStats();
+      const data = await getStats(signal);
       set({ stats: data });
+    } catch (e) {
+      if (!axios.isCancel(e)) throw e;
     } finally {
       set({ loading: false });
     }
   },
 
-  fetchStatus: async () => {
+  fetchStatus: async (signal) => {
     try {
-      const data = await getStatus();
+      const data = await getStatus(signal);
       set({ llmEnabled: data.llm_enabled });
     } catch {
-      // Non-fatal — banner simply won't show if status is unreachable
+      // Non-fatal — includes CanceledError
     }
   },
 }));

--- a/aegis/frontend/src/stores/tableStore.ts
+++ b/aegis/frontend/src/stores/tableStore.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { create } from "zustand";
 import type { MonitoredTable } from "../api/types";
 import { getTables } from "../api/endpoints";
@@ -5,18 +6,20 @@ import { getTables } from "../api/endpoints";
 interface TableState {
   tables: MonitoredTable[];
   loading: boolean;
-  fetchTables: (params?: { connection_id?: number }) => Promise<void>;
+  fetchTables: (params?: { connection_id?: number }, signal?: AbortSignal) => Promise<void>;
 }
 
 export const useTableStore = create<TableState>((set) => ({
   tables: [],
   loading: false,
 
-  fetchTables: async (params) => {
+  fetchTables: async (params, signal) => {
     set({ loading: true });
     try {
-      const data = await getTables(params);
+      const data = await getTables(params, signal);
       set({ tables: data });
+    } catch (e) {
+      if (!axios.isCancel(e)) throw e;
     } finally {
       set({ loading: false });
     }


### PR DESCRIPTION
## Summary

- Added `timeout: 30000` to the Axios client to prevent requests from hanging indefinitely when the backend is slow or unreachable
- Added `signal?: AbortSignal` to all API endpoints and Zustand store fetch methods so in-flight requests can be cancelled
- Added `AbortController` lifecycle management to all four data-fetching pages (`Overview`, `LineageExplorer`, `IncidentDetail`, `Settings`) — requests are automatically aborted when the component unmounts

## Details

**Root bug:** The Axios client had no timeout configured, leaving the UI in a permanent loading state if the backend hung. Verified fix by injecting a `time.sleep(120)` in the backend — Firefox showed `NS_BINDING_ABORTED` after 30 seconds.

**AbortController pattern used in pages:**

The controller effect is declared **before** any `useAutoRefresh` call to guarantee the signal is available when the first poll fires on mount.

**Excluded from AbortController:** `ConnectionForm`, `handleApprove`, `handleDismiss`, `handleDelete` — user-initiated mutations that should complete regardless of navigation.

## Test Plan

- [x] 16 unit tests across 4 store test files — signal forwarding, abort suppression, non-cancel rethrow
- [x] TypeScript compiles with no new errors (`npx tsc --noEmit`)
- [x] Manual verification: backend sleep test showed `NS_BINDING_ABORTED` after 30s

*Co-authored by @cyn-clical and @claude*